### PR TITLE
Set minimum Emacs version

### DIFF
--- a/loccur.el
+++ b/loccur.el
@@ -6,10 +6,10 @@
 ;;
 ;; Created: 2009-09-08
 ;; Version: 1.2.3
-;; Package-Requires: ((cl-lib "0"))
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: matching
 ;; URL: https://github.com/fourier/loccur
-;; Compatibility: GNU Emacs 23.x, GNU Emacs 24.x
+;; Compatibility: GNU Emacs 24.3
 ;;
 ;; This file is part of GNU Emacs.
 ;;


### PR DESCRIPTION
defvar-local was introduced at Emacs 24.3. And cl-lib was bundled since Emacs 24.3.