### PR TITLE
Autoload loccur command

### DIFF
--- a/loccur.el
+++ b/loccur.el
@@ -169,6 +169,7 @@ REGEX is regexp to search"
       (when (overlay-get ovl loccur-overlay-visible-property-name)
         (overlay-put ovl 'face (if loccur-highlight-matching-regexp 'loccur-face nil))))))
 
+;;;###autoload
 (defun loccur (regex)
   "Perform a simple grep in current buffer.
 


### PR DESCRIPTION
Since the command loccur will nearly always be called before loccur-mode, this should be autoloaded to avoid needing to explicitly require the mode (in this modern age of package-initialize).