### PR TITLE
Make the Isearch trick official

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,20 @@ Below is the list of interactive commands available for user:
 * `loccur-previous-match` repeat previous `loccur` command
 * `loccur-no-highlight` is the same as `loccur` but not highlighting matches
 * `loccur-toggle-highlight` toggles highlighting of matches
+* `loccur-isearch`: incremental occur (more details below)
 
 ### Customization
 * `loccur-jump-beginning-of-line` variable specifies if move the cursor to the beginning of the matching line. Default `nil`
 * `loccur-highlight-matching-regexp` variable whenever `loccur` should highlight matching words. Default `t`.
 * `loccur-face` face to be used while highlighting. Default points to `isearch` face.
 
-### Tips and tricks
-To combine **Loccur** and **isearch** functionality (narrowing-search) one can use the following hooks:
-```lisp
-(add-hook 'isearch-update-post-hook
-          (lambda ()
-            (let ((loccur-mode nil))
-              (loccur (regexp-quote isearch-string)))))
+### Isearch integration
+The `loccur-isearch` command filters buffer lines incrementally as you
+type a search string.  It can also be called when Isearch is already
+active to turn filtering on or off.  For the latter functionality, you
+should bind the command in `isearch-mode-map`, for example as follows:
 
-(add-hook 'isearch-mode-end-hook
-          (lambda ()
-            (loccur nil)))
+``` elisp
+(define-key global-map (kbd "M-s C-o") 'loccur-isearch)
+(define-key isearch-mode-map (kbd "C-o") 'loccur-isearch)
 ```

--- a/loccur.el
+++ b/loccur.el
@@ -6,10 +6,10 @@
 ;;
 ;; Created: 2009-09-08
 ;; Version: 1.2.4
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Keywords: matching
 ;; URL: https://github.com/fourier/loccur
-;; Compatibility: GNU Emacs 24.3
+;; Compatibility: GNU Emacs 25.1
 ;;
 ;; This file is part of GNU Emacs.
 ;;
@@ -350,9 +350,48 @@ containing match"
         (forward-line 1))
       (setq lines (nreverse lines)))))
 
+(defun loccur-isearch--update ()
+  "Apply `loccur' according the current Isearch state."
+  (let ((loccur-mode nil)
+        (loccur-highlight-matching-regexp nil)
+        (case-fold-search isearch-case-fold-search)
+        (search-spaces-regexp (if (if isearch-regexp
+                                      isearch-regexp-lax-whitespace
+                                    isearch-lax-whitespace)
+                                  search-whitespace-regexp)))
+    (loccur (cond
+	     ((functionp isearch-regexp-function)
+	      (funcall isearch-regexp-function isearch-string))
+	     (isearch-regexp-function (word-search-regexp isearch-string))
+	     (isearch-regexp isearch-string)
+	     (t (regexp-quote isearch-string))))))
 
+(defun loccur-isearch--exit ()
+  "Deactivate `loccur-isearch'."
+  (remove-hook 'isearch-update-post-hook 'loccur-isearch--update)
+  (remove-hook 'isearch-mode-end-hook 'loccur-isearch--exit)
+  (loccur nil))
 
+;;;###autoload
+(defun loccur-isearch (&optional mode)
+  "Incrementally filter buffer lines.
 
+Like Isearch, but hide buffer lines not matching the search
+string.  If Isearch is already active, toggle filtering on or
+off.
+
+MODE only has effect if called from outside Isearch, and has the
+same meaning as `search-default-mode'.  Interactively, that
+default value is used."
+  (interactive (list search-default-mode))
+  (unless isearch-mode
+    (isearch-mode t (eq t mode) nil nil (and (functionp mode) mode)))
+  (if (memq 'loccur-isearch--update isearch-update-post-hook)
+      (loccur-isearch--exit)
+    (add-hook 'isearch-update-post-hook 'loccur-isearch--update)
+    (add-hook 'isearch-mode-end-hook 'loccur-isearch--exit)
+    (isearch-update))
+  (funcall (or isearch-message-function #'isearch-message)))
 
 (provide 'loccur)
 ;;; loccur.el ends here


### PR DESCRIPTION
It's too nice to be relegated to a footnote, and it's also a bit trickier than indicated in the readme to make it work correctly.

I've increased the required Emacs version to 25.1 because that's when `search-default-mode` was introduced.

Also, may I suggest to change the default `loccur-face` to inherit from `lazy-highlight`, so it agrees with Isearch?